### PR TITLE
Organize end-to-end ESLint parity suite

### DIFF
--- a/.github/workflows/eslint-parity.yml
+++ b/.github/workflows/eslint-parity.yml
@@ -1,0 +1,47 @@
+name: ESLint parity verification
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  eslint-parity:
+    runs-on: ubuntu-latest
+    env:
+      FIXTURE_REPO: ${{ github.workspace }}/.fixtures/turborepo
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up PNPM
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'pnpm'
+
+      - name: Set up Neovim
+        uses: jghauser/setup-neovim@v1
+        with:
+          neovim-version: stable
+
+      - name: Clone turborepo fixture
+        run: |
+          git clone --depth 1 https://github.com/vercel/turborepo.git "$FIXTURE_REPO"
+
+      - name: Install turborepo dependencies
+        working-directory: ${{ env.FIXTURE_REPO }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Seed ESLint violations and verify parity
+        env:
+          NVIM_ESLINT_FIXTURE: ${{ env.FIXTURE_REPO }}
+        run: |
+          python tests/e2e/parity/run_eslint_parity_suite.py

--- a/tests/e2e/parity/README.md
+++ b/tests/e2e/parity/README.md
@@ -1,0 +1,65 @@
+# End-to-End ESLint parity verification
+
+This guide documents the end-to-end test suite that compares diagnostics from `nvim-eslint` against the official ESLint CLI. The harness reproduces the complete toolchain: it opens a real TypeScript workspace, seeds deterministic lint violations, gathers headless Neovim output, and asserts that the collected diagnostics match the CLI results.
+
+## Overview
+- **Test type:** End-to-end validation that exercises Neovim, the ESLint language server, and the target repository together.
+- **Location:** `tests/e2e/parity/`
+- **Primary scripts:**
+  - `seed_eslint_errors.py` injects reproducible ESLint violations into TypeScript files.
+  - `run_eslint_parity.py` runs the ESLint CLI, executes Neovim headlessly, and normalizes both JSON payloads.
+  - `run_eslint_parity_suite.py` orchestrates multi-file parity checks for CI.
+
+## Prerequisites
+- Neovim 0.10 or newer (the plugin depends on `vim.fs.root`).
+- Node.js 18+, PNPM, and the ability to install workspace dependencies.
+- Python 3.10+ for the helper scripts.
+- Network access to clone the `turborepo` fixture unless you supply `NVIM_ESLINT_FIXTURE` yourself.
+
+## Prepare the fixture repository
+```bash
+export NVIM_ESLINT_FIXTURE=/workspace/turborepo
+rm -rf "$NVIM_ESLINT_FIXTURE"
+git clone --depth 1 https://github.com/vercel/turborepo.git "$NVIM_ESLINT_FIXTURE"
+cd "$NVIM_ESLINT_FIXTURE"
+pnpm install --frozen-lockfile
+```
+
+## Seed deterministic ESLint violations
+Use the helper to append violations to any TypeScript source file inside the fixture. The injected block is wrapped in an IIFE so the new symbols stay scoped.
+```bash
+python tests/e2e/parity/seed_eslint_errors.py "$NVIM_ESLINT_FIXTURE/packages/create-turbo/src/cli.ts"
+```
+Pass `--errors` to focus on a subset of rules (supported values: `unused-vars`, `explicit-any`, `prefer-const`, `no-console`, `eqeqeq`). Running the helper again removes the previous block before re-injecting fresh snippets.
+
+## Compare ESLint CLI and headless Neovim output
+Invoke the parity script to ensure the normalized ESLint CLI JSON matches the collector output.
+```bash
+python tests/e2e/parity/run_eslint_parity.py \
+  --fixture-root "$NVIM_ESLINT_FIXTURE" \
+  --target packages/create-turbo/src/cli.ts
+```
+The script prints:
+1. Raw ESLint CLI JSON (`--format json`).
+2. Headless collector JSON emitted from Neovim.
+3. A canonicalized diff-friendly structure that ignores ordering differences.
+
+The command exits with status `0` when both results align, or `1` with a summary when they differ.
+
+## Run the full end-to-end suite
+Execute the orchestrator to seed and lint five representative entry points. The helper runs `run_eslint_parity.py` for each target and fails fast if any comparison diverges.
+```bash
+python tests/e2e/parity/run_eslint_parity_suite.py \
+  --fixture-root "$NVIM_ESLINT_FIXTURE" \
+  --nvim-cmd /path/to/nvim
+```
+Environment variables:
+- `NVIM_ESLINT_FIXTURE` overrides `--fixture-root` when the flag is omitted.
+
+Useful flags:
+- `--errors` limits the seeded rules for every file.
+- `--skip-seed` reuses existing violations (helpful for debugging).
+- `--timeout` adjusts the milliseconds the collector waits for diagnostics (default: `20000`).
+
+## Continuous integration
+The GitHub Actions workflow `.github/workflows/eslint-parity.yml` provisions Neovim, Node.js, and PNPM, clones the turborepo fixture, installs dependencies, and runs `python tests/e2e/parity/run_eslint_parity_suite.py` on every push and pull request targeting `main`.

--- a/tests/e2e/parity/headless_collect.lua
+++ b/tests/e2e/parity/headless_collect.lua
@@ -1,0 +1,146 @@
+local M = {}
+
+local function wait_for(predicate, timeout_ms, interval_ms)
+  local waited = 0
+  interval_ms = interval_ms or 100
+
+  while waited < timeout_ms do
+    if predicate() then
+      return true
+    end
+
+    vim.wait(interval_ms)
+    waited = waited + interval_ms
+  end
+
+  return predicate()
+end
+
+local function to_eslint_json(bufnr, diagnostics)
+  local severity_map = {
+    [vim.diagnostic.severity.ERROR] = 2,
+    [vim.diagnostic.severity.WARN] = 1,
+    [vim.diagnostic.severity.INFO] = 1,
+    [vim.diagnostic.severity.HINT] = 1,
+  }
+
+  local result = {
+    filePath = vim.api.nvim_buf_get_name(bufnr),
+    messages = {},
+    suppressedMessages = {},
+    errorCount = 0,
+    fatalErrorCount = 0,
+    warningCount = 0,
+    fixableErrorCount = 0,
+    fixableWarningCount = 0,
+    usedDeprecatedRules = {},
+  }
+
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  result.source = table.concat(lines, "\n")
+
+  local function get_rule_id(diagnostic)
+    if diagnostic.code and diagnostic.code ~= "" then
+      return diagnostic.code
+    end
+
+    local lsp_data = diagnostic.user_data and diagnostic.user_data.lsp
+    if lsp_data and lsp_data.code and lsp_data.code ~= "" then
+      return lsp_data.code
+    end
+
+    return vim.NIL
+  end
+
+  local function to_message(diagnostic)
+    local severity = severity_map[diagnostic.severity] or 1
+    local message = {
+      ruleId = get_rule_id(diagnostic),
+      severity = severity,
+      message = diagnostic.message or "",
+      line = (diagnostic.lnum or 0) + 1,
+      column = (diagnostic.col or 0) + 1,
+      endLine = diagnostic.end_lnum and (diagnostic.end_lnum + 1) or vim.NIL,
+      endColumn = diagnostic.end_col and (diagnostic.end_col + 1) or vim.NIL,
+      nodeType = vim.NIL,
+      messageId = vim.NIL,
+      fix = vim.NIL,
+      fatal = vim.NIL,
+      suggestions = vim.NIL,
+    }
+
+    local lsp_data = diagnostic.user_data and diagnostic.user_data.lsp
+    if lsp_data then
+      if message.ruleId == vim.NIL and lsp_data.code and lsp_data.code ~= "" then
+        message.ruleId = lsp_data.code
+      end
+
+      if lsp_data.message and lsp_data.message ~= "" then
+        message.message = lsp_data.message
+      end
+
+      if lsp_data.severity then
+        severity = severity_map[lsp_data.severity] or severity
+        message.severity = severity
+      end
+
+      if lsp_data.data then
+        message.nodeType = lsp_data.data.nodeType or message.nodeType
+        message.messageId = lsp_data.data.messageId or message.messageId
+        message.suggestions = lsp_data.data.suggestions or message.suggestions
+      end
+    end
+
+    if severity == 2 then
+      result.errorCount = result.errorCount + 1
+    else
+      result.warningCount = result.warningCount + 1
+    end
+
+    return message
+  end
+
+  for _, diagnostic in ipairs(diagnostics) do
+    table.insert(result.messages, to_message(diagnostic))
+  end
+
+  return { result }
+end
+
+function M.collect(opts)
+  opts = opts or {}
+  local bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
+  local timeout = opts.timeout or 10000
+
+  local attached = wait_for(function()
+    local clients = vim.lsp.get_clients({ bufnr = bufnr })
+    for _, client in ipairs(clients) do
+      if client.name == "eslint" then
+        return true
+      end
+    end
+    return false
+  end, timeout, 100)
+
+  if not attached then
+    vim.api.nvim_err_writeln("eslint LSP did not attach within timeout")
+    return false
+  end
+
+  wait_for(function()
+    local diags = vim.diagnostic.get(bufnr)
+    return #diags > 0
+  end, timeout, 100)
+
+  local diagnostics = vim.diagnostic.get(bufnr)
+  if #diagnostics == 0 then
+    vim.api.nvim_err_writeln("No diagnostics collected")
+  else
+    local eslint_like = to_eslint_json(bufnr, diagnostics)
+    vim.api.nvim_out_write(vim.fn.json_encode(eslint_like) .. "\n")
+  end
+
+  return true
+end
+
+return M

--- a/tests/e2e/parity/headless_init.lua
+++ b/tests/e2e/parity/headless_init.lua
@@ -1,0 +1,7 @@
+local script_path = debug.getinfo(1, "S").source:sub(2)
+local script_dir = vim.fn.fnamemodify(script_path, ":p:h")
+local repo_root = vim.fn.fnamemodify(script_dir, ":h:h:h")
+
+vim.opt.runtimepath:append(repo_root)
+
+require("nvim-eslint").setup({})

--- a/tests/e2e/parity/run_eslint_parity.py
+++ b/tests/e2e/parity/run_eslint_parity.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Compare ESLint CLI diagnostics with headless Neovim output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parents[2]
+DEFAULT_INIT = SCRIPT_DIR / "headless_init.lua"
+DEFAULT_COLLECTOR = SCRIPT_DIR / "headless_collect.lua"
+
+
+def run_command(command: List[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+
+
+def load_json(output: str, *, label: str) -> Any:
+    text = output.strip()
+    if not text:
+        raise ValueError(f"{label} produced no JSON output")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Failed to parse {label} JSON: {exc}\nRaw output:\n{text}") from exc
+
+
+def canonicalize(results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    canonical: List[Dict[str, Any]] = []
+    for entry in results:
+        messages = []
+        for message in entry.get("messages", []):
+            messages.append(
+                {
+                    "ruleId": message.get("ruleId"),
+                    "severity": message.get("severity"),
+                    "message": message.get("message"),
+                    "line": message.get("line"),
+                    "column": message.get("column"),
+                    "endLine": message.get("endLine"),
+                    "endColumn": message.get("endColumn"),
+                }
+            )
+        messages.sort(key=lambda item: (item.get("line"), item.get("column"), item.get("ruleId"), item.get("message")))
+        error_count = sum(1 for msg in messages if msg.get("severity") == 2)
+        warning_count = sum(1 for msg in messages if msg.get("severity") != 2)
+        canonical.append(
+            {
+                "filePath": entry.get("filePath"),
+                "messages": messages,
+                "errorCount": entry.get("errorCount", error_count),
+                "warningCount": entry.get("warningCount", warning_count),
+            }
+        )
+    canonical.sort(key=lambda item: item.get("filePath"))
+    return canonical
+
+
+def resolve_repo_path(value: str | Path) -> Path:
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    return (REPO_ROOT / path).resolve()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Compare ESLint CLI output with headless Neovim diagnostics")
+    parser.add_argument("--fixture-root", default="/workspace/turborepo", help="Path to the sample repository to lint")
+    parser.add_argument("--target", default="packages/create-turbo/src/cli.ts", help="Relative path to the file to lint")
+    parser.add_argument("--eslint-cmd", default="pnpm exec eslint", help="Command used to invoke the ESLint CLI")
+    parser.add_argument("--nvim-cmd", default="nvim", help="Neovim executable to run in headless mode")
+    parser.add_argument("--init", default=str(DEFAULT_INIT), help="Neovim init file that loads the plugin")
+    parser.add_argument("--collector", default=str(DEFAULT_COLLECTOR), help="Collector script to execute inside Neovim")
+    parser.add_argument("--timeout", type=int, default=20000, help="Timeout (ms) for the collector to wait for diagnostics")
+    args = parser.parse_args()
+
+    repo_root = REPO_ROOT
+    fixture_root = Path(args.fixture_root).resolve()
+    target_path = fixture_root / args.target
+
+    if not target_path.exists():
+        print(f"Target file {target_path} does not exist", file=sys.stderr)
+        return 2
+
+    eslint_cmd = shlex.split(args.eslint_cmd) + [args.target, "--format", "json"]
+    eslint_result = run_command(eslint_cmd, cwd=fixture_root)
+    if eslint_result.returncode not in (0, 1):
+        print("ESLint CLI failed:", file=sys.stderr)
+        sys.stderr.write(eslint_result.stdout)
+        sys.stderr.write(eslint_result.stderr)
+        return eslint_result.returncode
+
+    init_path = resolve_repo_path(args.init)
+    collector_path = resolve_repo_path(args.collector)
+
+    collector_expr = (
+        "lua local collector = dofile(%r); collector.collect({ timeout = %d })"
+        % (str(collector_path), args.timeout)
+    )
+
+    headless_cmd = (
+        shlex.split(args.nvim_cmd)
+        + [
+            "--headless",
+            "-u",
+            str(init_path),
+            str(target_path),
+            f"+{collector_expr}",
+            "+qa",
+        ]
+    )
+    headless_result = run_command(headless_cmd, cwd=repo_root)
+    if headless_result.returncode != 0:
+        print("Headless Neovim run failed:", file=sys.stderr)
+        sys.stderr.write(headless_result.stdout)
+        sys.stderr.write(headless_result.stderr)
+        return headless_result.returncode
+
+    try:
+        eslint_json = load_json(eslint_result.stdout, label="ESLint CLI")
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    headless_output = headless_result.stdout if headless_result.stdout.strip() else headless_result.stderr
+    try:
+        headless_json = load_json(headless_output, label="headless collector")
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    canonical_cli = canonicalize(eslint_json)
+    canonical_headless = canonicalize(headless_json)
+
+    print("=== ESLint CLI JSON ===")
+    print(json.dumps(eslint_json, indent=2, ensure_ascii=False))
+    print("=== Headless Neovim JSON ===")
+    print(json.dumps(headless_json, indent=2, ensure_ascii=False))
+    print("=== Canonical comparison ===")
+    print(json.dumps({"cli": canonical_cli, "headless": canonical_headless}, indent=2, ensure_ascii=False))
+
+    if canonical_cli == canonical_headless:
+        print("SUCCESS: headless Neovim diagnostics match ESLint CLI output")
+        return 0
+
+    print("FAILURE: headless Neovim diagnostics differ from ESLint CLI output", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e/parity/run_eslint_parity_suite.py
+++ b/tests/e2e/parity/run_eslint_parity_suite.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Seed ESLint violations and verify Neovim parity across multiple files."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SEED_SCRIPT = SCRIPT_DIR / "seed_eslint_errors.py"
+PARITY_SCRIPT = SCRIPT_DIR / "run_eslint_parity.py"
+
+DEFAULT_TARGETS = [
+    "packages/create-turbo/src/cli.ts",
+    "packages/turbo-workspaces/src/cli.ts",
+    "packages/turbo-telemetry/src/cli.ts",
+    "packages/turbo-codemod/src/cli.ts",
+    "packages/turbo-gen/src/cli.ts",
+]
+
+
+def run_command(command: List[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+
+
+def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Inject ESLint violations into multiple files and compare CLI output with headless Neovim diagnostics.",
+    )
+    parser.add_argument(
+        "--fixture-root",
+        default=os.environ.get("NVIM_ESLINT_FIXTURE", "/workspace/turborepo"),
+        help="Path to the sample repository to lint.",
+    )
+    parser.add_argument(
+        "--targets",
+        nargs="+",
+        default=DEFAULT_TARGETS,
+        help="Relative paths (from fixture root) of the files to seed and lint.",
+    )
+    parser.add_argument(
+        "--errors",
+        nargs="+",
+        help="Subset of ESLint violations to inject before linting.",
+    )
+    parser.add_argument(
+        "--eslint-cmd",
+        default="pnpm exec eslint",
+        help="Command used to invoke the ESLint CLI.",
+    )
+    parser.add_argument(
+        "--nvim-cmd",
+        default="nvim",
+        help="Neovim executable to run in headless mode.",
+    )
+    parser.add_argument(
+        "--init",
+        default=str(SCRIPT_DIR / "headless_init.lua"),
+        help="Neovim init file that loads the plugin.",
+    )
+    parser.add_argument(
+        "--collector",
+        default=str(SCRIPT_DIR / "headless_collect.lua"),
+        help="Collector script executed inside Neovim to emit diagnostics.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=20000,
+        help="Timeout (ms) for the collector to wait for diagnostics.",
+    )
+    parser.add_argument(
+        "--skip-seed",
+        action="store_true",
+        help="Skip injecting ESLint violations before running the parity checks.",
+    )
+    return parser.parse_args(argv)
+
+
+def seed_errors(fixture_root: Path, target: str, errors: List[str] | None) -> None:
+    target_path = fixture_root / target
+    if not target_path.exists():
+        raise FileNotFoundError(f"Target file {target_path} does not exist")
+
+    command = [sys.executable, str(SEED_SCRIPT), str(target_path)]
+    if errors:
+        command.extend(["--errors", *errors])
+
+    result = run_command(command)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Failed to seed ESLint violations for {target}:\n{result.stdout}{result.stderr}"
+        )
+
+
+def run_parity(fixture_root: Path, args: argparse.Namespace, target: str) -> int:
+    command = [
+        sys.executable,
+        str(PARITY_SCRIPT),
+        "--fixture-root",
+        str(fixture_root),
+        "--target",
+        target,
+        "--eslint-cmd",
+        args.eslint_cmd,
+        "--nvim-cmd",
+        args.nvim_cmd,
+        "--init",
+        args.init,
+        "--collector",
+        args.collector,
+        "--timeout",
+        str(args.timeout),
+    ]
+    result = run_command(command)
+    if result.stdout:
+        sys.stdout.write(result.stdout)
+    if result.stderr:
+        sys.stderr.write(result.stderr)
+    return result.returncode
+
+
+def main(argv: List[str] | None = None) -> int:
+    args = parse_args(argv)
+    fixture_root = Path(args.fixture_root).resolve()
+
+    if not fixture_root.exists():
+        print(f"Fixture repository {fixture_root} does not exist", file=sys.stderr)
+        return 2
+
+    failures: list[str] = []
+    for target in args.targets:
+        print("==============================")
+        print(f"Target: {target}")
+        print("==============================")
+
+        try:
+            if not args.skip_seed:
+                seed_errors(fixture_root, target, args.errors)
+        except Exception as exc:  # noqa: BLE001
+            print(f"Seeding failed for {target}: {exc}", file=sys.stderr)
+            failures.append(target)
+            continue
+
+        status = run_parity(fixture_root, args, target)
+        if status != 0:
+            print(f"Parity check failed for {target}", file=sys.stderr)
+            failures.append(target)
+
+    if failures:
+        print("", file=sys.stderr)
+        print("Failed targets:", file=sys.stderr)
+        for entry in failures:
+            print(f" - {entry}", file=sys.stderr)
+        return 1
+
+    print("All targets matched ESLint CLI output.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/e2e/parity/seed_eslint_errors.py
+++ b/tests/e2e/parity/seed_eslint_errors.py
@@ -1,0 +1,157 @@
+"""Utilities for injecting common ESLint violations into TypeScript files.
+
+The script lets the test workflow seed deterministic lint errors before
+running the parity harness. Each supported violation is generated inside an
+IIFE to keep the injected symbols scoped and avoid interfering with existing
+code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+
+ERROR_CHOICES = (
+    "unused-vars",
+    "explicit-any",
+    "prefer-const",
+    "no-console",
+    "eqeqeq",
+)
+
+BLOCK_BEGIN = "// ESLINT_ERROR_GENERATOR:BEGIN"
+BLOCK_END = "// ESLINT_ERROR_GENERATOR:END"
+
+
+def build_snippet(selected: list[str]) -> str:
+    snippets: dict[str, str] = {
+        "unused-vars": dedent(
+            """\
+            (() => {
+              // ESLINT_ERROR unused-vars
+              const ESLINT_ERROR_UNUSED = 42;
+            })();
+            """
+        ).strip()
+        + "\n",
+        "explicit-any": dedent(
+            """\
+            (() => {
+              // ESLINT_ERROR explicit-any
+              const ESLINT_ERROR_EXPLICIT_ANY: any = {};
+
+              if (typeof ESLINT_ERROR_EXPLICIT_ANY === "string") {
+                throw new Error("ESLint explicit-any violation");
+              }
+            })();
+            """
+        ).strip()
+        + "\n",
+        "prefer-const": dedent(
+            """\
+            (() => {
+              // ESLINT_ERROR prefer-const
+              let ESLINT_ERROR_SHOULD_BE_CONST = "value";
+
+              const useConst = () => ESLINT_ERROR_SHOULD_BE_CONST;
+              useConst();
+            })();
+            """
+        ).strip()
+        + "\n",
+        "no-console": dedent(
+            """\
+            (() => {
+              // ESLINT_ERROR no-console
+              console.log("ESLint no-console violation");
+            })();
+            """
+        ).strip()
+        + "\n",
+        "eqeqeq": dedent(
+            """\
+            (() => {
+              // ESLINT_ERROR eqeqeq
+              if (Math.random() == 0) {
+                throw new Error("ESLint eqeqeq violation");
+              }
+            })();
+            """
+        ).strip()
+        + "\n",
+    }
+
+    return "".join(snippets[name] for name in selected)
+
+
+def inject_errors(file_path: Path, selected: list[str]) -> None:
+    if not file_path.exists():
+        raise FileNotFoundError(f"Target file {file_path} does not exist")
+
+    if file_path.suffix not in {".ts", ".tsx"}:
+        raise ValueError("This helper only supports TypeScript source files")
+
+    original = file_path.read_text()
+
+    begin_idx = original.find(BLOCK_BEGIN)
+    if begin_idx != -1:
+        end_idx = original.find(BLOCK_END, begin_idx)
+        if end_idx == -1:
+            raise RuntimeError(
+                "Found block begin marker without a matching end marker"
+            )
+
+        end_idx += len(BLOCK_END)
+        if end_idx < len(original) and original[end_idx] == "\n":
+            end_idx += 1
+        original = original[:begin_idx] + original[end_idx:]
+
+    snippet_body = build_snippet(selected)
+    if not snippet_body:
+        return
+
+    if original and not original.endswith("\n"):
+        original += "\n"
+
+    block = [BLOCK_BEGIN, snippet_body.rstrip("\n"), BLOCK_END, ""]
+    updated = original + "\n".join(block)
+
+    file_path.write_text(updated)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inject deterministic ESLint violations into a TypeScript file."
+        )
+    )
+    parser.add_argument(
+        "path",
+        type=Path,
+        help="Path to the TypeScript file that should receive the violations",
+    )
+    parser.add_argument(
+        "--errors",
+        choices=ERROR_CHOICES,
+        nargs="+",
+        default=list(ERROR_CHOICES),
+        help=(
+            "Subset of violations to generate. Defaults to seeding all supported"
+            " error types."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+
+    inject_errors(args.path, list(dict.fromkeys(args.errors)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- replace the exploratory headless testing log with a concise end-to-end parity guide now hosted at `tests/e2e/parity/README.md`, walking through setup, execution, and CI automation
- move the parity helpers into `tests/e2e/parity/`, teaching the harnesses to resolve helper paths from their new home and updating the headless init script accordingly
- point the GitHub Actions workflow at the relocated suite entry point so CI continues to exercise the parity checks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e492df7f24832daa7857ee92de1dfe