### PR TITLE
fix: use vim.fn.exepath for node path resolution

### DIFF
--- a/lua/nvim-eslint/settings.lua
+++ b/lua/nvim-eslint/settings.lua
@@ -42,13 +42,9 @@ function M.use_flat_config(bufnr)
 end
 
 function M.resolve_node_path()
-  local is_windows = vim.loop.os_uname().sysname == 'Windows_NT'
-  local command = is_windows and 'where.exe node' or 'which node'
+  local result = vim.fn.exepath('node')
 
-  local result = vim.fn.system(command)
-  result = result:gsub('\r\n$', ''):gsub('\n$', '')
-
-  if vim.v.shell_error ~= 0 then
+  if result == '' then
     print('Error: Could not find Node.js path. ESLint server will use default path.')
     return nil
   end

--- a/lua/nvim-eslint/settings.lua
+++ b/lua/nvim-eslint/settings.lua
@@ -45,7 +45,7 @@ function M.resolve_node_path()
   local result = vim.fn.exepath('node')
 
   if result == '' then
-    print('Error: Could not find Node.js path. ESLint server will use default path.')
+    vim.notify('ESLint: Could not find Node.js path. ESLint server will use default path.', vim.log.levels.WARN)
     return nil
   end
 


### PR DESCRIPTION
This replaces the system(where.exe node) call with vim.fn.exepath(node). On Windows, where.exe is very slow (~500ms) and blocks the UI. vim.fn.exepath is native and instant (~10ms).